### PR TITLE
Fix spelling of excercise -> exercise

### DIFF
--- a/.answers/03.broken_function.py
+++ b/.answers/03.broken_function.py
@@ -45,7 +45,7 @@ for case in TEST_CASES:
 from typing import Union, List
 
 
-def extension_excercise(name: Union[str, list ]) -> str:
+def extension_exercise(name: Union[str, list ]) -> str:
     """If you fancy a challenge try doing the same here...
 
     (
@@ -60,4 +60,4 @@ def extension_excercise(name: Union[str, list ]) -> str:
 
 
 for case in TEST_CASES:
-    print(extension_excercise(case))
+    print(extension_exercise(case))

--- a/.answers/03.broken_function.py.diff
+++ b/.answers/03.broken_function.py.diff
@@ -4,22 +4,22 @@ index f2a0117..a7f45a2 100644
 +++ b/.answers/03.broken_function.py
 @@ -27,7 +27,7 @@ It's taken pretty directly from the MyPy docs
  """
- 
- 
+
+
 -def hello(name):
 +def hello(name: str) -> str:
      return f'hello {name}'
- 
- 
+
+
 @@ -42,7 +42,10 @@ for case in TEST_CASES:
      print(hello(case))
- 
- 
--def extension_excercise(name):
+
+
+-def extension_exercise(name):
 +from typing import Union, List
 +
 +
-+def extension_excercise(name: Union[str, list ]) -> str:
++def extension_exercise(name: Union[str, list ]) -> str:
      """If you fancy a challenge try doing the same here...
- 
+
      (

--- a/03.broken_function.py
+++ b/03.broken_function.py
@@ -2,7 +2,7 @@
 Aim
 ===
 
-By the end of this excercise you should be able to use MyPy
+By the end of this exercise you should be able to use MyPy
 annotation syntax for a basic function:
 
 ```python
@@ -43,7 +43,7 @@ for case in TEST_CASES:
     print(hello(case))
 
 
-def extension_excercise(name):
+def extension_exercise(name):
     """If you fancy a challenge try doing the same here...
 
     (
@@ -58,4 +58,4 @@ def extension_excercise(name):
 
 
 for case in TEST_CASES:
-    print(extension_excercise(case))
+    print(extension_exercise(case))

--- a/04.add_typing.py
+++ b/04.add_typing.py
@@ -2,7 +2,7 @@
 Aim
 ===
 
-By the end of this excercise you should be able to add more complex
+By the end of this exercise you should be able to add more complex
 static typing to functions using the ``typing`` module.
 
 Task

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Contents:
 
 - Why bother with MyPy.
 - Two example scripts.
-- Two excercise scripts.
+- Two exercise scripts.
 
 ---
 
@@ -91,5 +91,5 @@ Either:
 
 1. [Brief introduction to the syntax.](01.basic_syntax.py) ([Answers](.answers/01.basic_syntax.py.diff))
 2. [An example where type annotation would have made my life better.](02.real_world_example.py) ([Answers](.answers/02.real_world_example.py.diff))
-3. [Excercise 1: Make a broken function fail MyPy validation](03.broken_function.py) ([Answers](answers/03.broken_function.py.diff))
-4. [Excercise 2: Use MyPy on some example legacy code.](04.add_typing.py) ([Answers](.answers/04.add_typing.py.diff))
+3. [Exercise 1: Make a broken function fail MyPy validation](03.broken_function.py) ([Answers](answers/03.broken_function.py.diff))
+4. [Exercise 2: Use MyPy on some example legacy code.](04.add_typing.py) ([Answers](.answers/04.add_typing.py.diff))

--- a/slides.html
+++ b/slides.html
@@ -99,7 +99,7 @@
 <ul>
 <li>Why bother with MyPy.</li>
 <li>Two example scripts.</li>
-<li>Two excercise scripts.</li>
+<li>Two exercise scripts.</li>
 </ul>
 </section>
 <section class="slide level1">
@@ -151,8 +151,8 @@
 <ol type="1">
 <li><a href="01.basic_syntax.py">Brief introduction to the syntax.</a> (<a href=".answers/01.basic_syntax.py.diff">Answers</a>)</li>
 <li><a href="02.real_world_example.py">An example where type annotation would have made my life better.</a> (<a href=".answers/02.real_world_example.py.diff">Answers</a>)</li>
-<li><a href="03.broken_function.py">Excercise 1: Make a broken function fail MyPy validation</a> (<a href="answers/03.broken_function.py.diff">Answers</a>)</li>
-<li><a href="04.add_typing.py">Excercise 2: Use MyPy on some example legacy code.</a> (<a href=".answers/04.add_typing.py.diff">Answers</a>)</li>
+<li><a href="03.broken_function.py">Exercise 1: Make a broken function fail MyPy validation</a> (<a href="answers/03.broken_function.py.diff">Answers</a>)</li>
+<li><a href="04.add_typing.py">Exercise 2: Use MyPy on some example legacy code.</a> (<a href=".answers/04.add_typing.py.diff">Answers</a>)</li>
 </ol>
 </section>
     </div>


### PR DESCRIPTION
Very pedantic! Ensure that the correct "exercise" spelling is used throughout.

This has also fixed what I think is rendered output (slides.html) so no need to re-render.

Before (ignoring stuff in ./.git):
```bash
:> grep -irn xcercise .
./.answers/03.broken_function.py:48:def extension_excercise(name: Union[str, list ]) -> str:
./.answers/03.broken_function.py:63:    print(extension_excercise(case))
./.answers/03.broken_function.py.diff:18:-def extension_excercise(name):
./.answers/03.broken_function.py.diff:22:+def extension_excercise(name: Union[str, list ]) -> str:
./03.broken_function.py:5:By the end of this excercise you should be able to use MyPy
./03.broken_function.py:46:def extension_excercise(name):
./03.broken_function.py:61:    print(extension_excercise(case))
./04.add_typing.py:5:By the end of this excercise you should be able to add more complex
./README.md:16:- Two excercise scripts.
./README.md:94:3. [Excercise 1: Make a broken function fail MyPy validation](03.broken_function.py) ([Answers](answers/03.broken_function.py.diff))
./README.md:95:4. [Excercise 2: Use MyPy on some example legacy code.](04.add_typing.py) ([Answers](.answers/04.add_typing.py.diff))
./slides.html:102:<li>Two excercise scripts.</li>
./slides.html:154:<li><a href="03.broken_function.py">Excercise 1: Make a broken function fail MyPy validation</a> (<a href="answers/03.broken_function.py.diff">Answers</a>)</li>
./slides.html:155:<li><a href="04.add_typing.py">Excercise 2: Use MyPy on some example legacy code.</a> (<a href=".answers/04.add_typing.py.diff">Answers</a>)</li>
```

After (ignoring stuff in ./.git):
```bash
:> grep -irn xcercise .
:>
```